### PR TITLE
Make floating label text crisper when floating

### DIFF
--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -156,13 +156,13 @@ var TextField = React.createClass({
 
     if (this.state.isFocused) {
       styles.floatingLabel.color = this.getTheme().primary1Color;
-      styles.floatingLabel.transform = 'scale(0.75) translate3d(0, -18px, 0)';
+      styles.floatingLabel.transform = 'perspective(1px) scale(0.75) translate3d(0, -18px, 0)';
       styles.focusUnderline.transform = 'scaleX(1)';
     }
 
     if (this.state.hasValue) {
       styles.floatingLabel.color = ColorManipulator.fade(this.getTheme().textColor, 0.5);
-      styles.floatingLabel.transform = 'scale(0.75) translate3d(0, -18px, 0)';
+      styles.floatingLabel.transform = 'perspective(1px) scale(0.75) translate3d(0, -18px, 0)';
       styles.hint.opacity = 0;
     }
 


### PR DESCRIPTION
Doesn't seem to be a way to apply this via themes - so this is a better default
